### PR TITLE
fix: 修复某些 ePub 文件获取目录为空的 Bug #208

### DIFF
--- a/packages/epub/src/index.ts
+++ b/packages/epub/src/index.ts
@@ -4,11 +4,13 @@
 
 import { EventEmitter } from 'events';
 import { join, dirname } from 'path';
-import { defaults as xml2js, Parser } from 'xml2js';
+import { defaults as xml2js, processors, Parser } from 'xml2js';
 import AdmZip from 'adm-zip';
 import { fromByteArray } from 'base64-js';
 
 const xml2jsOptions = xml2js['0.1'];
+xml2jsOptions.tagNameProcessors = [processors.stripPrefix];
+xml2jsOptions.attrNameProcessors = [processors.stripPrefix];
 
 class Zip {
   admZip: AdmZip;


### PR DESCRIPTION
修改 epub 库中解析 XML 文件使用的 `xml2jsOptions` 配置， 自动剥除 tag 和 attr 的 xmlns 前缀