### PR TITLE
feat(vscode): add EPUB annotations

### DIFF
--- a/docs/vsc/index.md
+++ b/docs/vsc/index.md
@@ -50,6 +50,16 @@ outline: deep
 
 ![1](https://github.com/aooiuu/any-reader-vscode/assets/28108111/fff2e255-5e09-4bff-b45c-78070dce8afc)
 
+## EPUB 批注
+
+VSCode 中直接打开本地 EPUB 文件时，可以选中文本创建高亮，也可以给高亮添加文字批注。批注不会写回 EPUB 原文件，而是保存到 EPUB 同目录的 sidecar 文件：
+
+```text
+<book>.epub.any-reader.annotations.json
+```
+
+sidecar 会保存章节、选中文本、前后文、颜色和批注文本，方便后续由脚本或大模型读取。
+
 ### 视频
 
 > 内置视频播放暂时只支持 [vscodium](https://github.com/VSCodium/vscodium) 不支持 vscode

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "eslint": "^8.57.1",
     "eslint-plugin-vue": "^9.29.0",
     "husky": "^8.0.3",
+    "lint-staged": "15.2.10",
     "npm-run-all2": "^6.2.3",
     "playwright": "^1.48.0",
     "ts-node": "^10.9.2",

--- a/packages/shared/__test__/unit/annotations.test.ts
+++ b/packages/shared/__test__/unit/annotations.test.ts
@@ -1,0 +1,121 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ReaderAnnotation } from '../../src/utils/annotations';
+import { getAnnotationSidecarPath, listAnnotations, readAnnotationFile, removeAnnotation, upsertAnnotation } from '../../src/utils/annotations';
+
+let tempDir = '';
+
+function createAnnotation(id: string, filePath: string, chapterPath = 'chapter-1'): ReaderAnnotation {
+  return {
+    id,
+    kind: 'highlight',
+    color: 'yellow',
+    note: 'note',
+    createdAt: '',
+    updatedAt: '',
+    target: {
+      source: 'OEBPS/chapter-1.xhtml',
+      type: 'application/xhtml+xml',
+      filePath,
+      chapterPath,
+      chapterHref: 'OEBPS/chapter-1.xhtml',
+      chapterTitle: 'Chapter 1',
+      selectors: [
+        {
+          type: 'TextQuoteSelector',
+          exact: 'selected text',
+          prefix: 'before ',
+          suffix: ' after'
+        },
+        {
+          type: 'CssSelector',
+          value: '[data-idx="0"]',
+          refinedBy: {
+            type: 'TextPositionSelector',
+            start: 1,
+            end: 14
+          }
+        },
+        {
+          type: 'AnyReaderDomRangeSelector',
+          startPath: [0],
+          startOffset: 1,
+          endPath: [0],
+          endOffset: 14
+        },
+        {
+          type: 'ProgressionSelector',
+          value: 0.25
+        }
+      ]
+    },
+    llm: {
+      sourceFile: filePath,
+      citation: 'Chapter 1: selected text',
+      chapterTitle: 'Chapter 1',
+      quote: 'selected text',
+      before: 'before ',
+      after: ' after',
+      note: 'note'
+    }
+  };
+}
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'any-reader-annotations-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe('annotation sidecar store', () => {
+  it('uses the EPUB sidecar naming convention', () => {
+    expect(getAnnotationSidecarPath('/books/My Book.epub')).toBe('/books/My Book.epub.any-reader.annotations.json');
+    expect(getAnnotationSidecarPath('C:\\Books\\中文 Book.epub')).toBe('C:\\Books\\中文 Book.epub.any-reader.annotations.json');
+  });
+
+  it('returns an empty annotation file when the sidecar does not exist', async () => {
+    const filePath = path.join(tempDir, 'empty book.epub');
+    const data = await readAnnotationFile(filePath);
+
+    expect(data.sourceFile).toBe(filePath);
+    expect(data.sourceName).toBe('empty book.epub');
+    expect(data.annotations).toEqual([]);
+  });
+
+  it('upserts, filters, and removes annotations', async () => {
+    const filePath = path.join(tempDir, '测试 book.epub');
+    const first = await upsertAnnotation({ filePath, annotation: createAnnotation('a1', filePath) });
+    await upsertAnnotation({ filePath, annotation: createAnnotation('a2', filePath, 'chapter-2') });
+    const updated = await upsertAnnotation({
+      filePath,
+      annotation: {
+        ...first,
+        note: 'updated note',
+        llm: {
+          ...first.llm,
+          note: 'updated note'
+        }
+      }
+    });
+
+    expect(updated.createdAt).toBe(first.createdAt);
+    expect(updated.updatedAt >= first.updatedAt).toBe(true);
+    expect(await listAnnotations({ filePath })).toHaveLength(2);
+    expect(await listAnnotations({ filePath, chapterPath: 'chapter-1' })).toMatchObject([{ id: 'a1', note: 'updated note' }]);
+
+    expect(await removeAnnotation({ filePath, id: 'a1' })).toEqual({ removed: true });
+    expect(await removeAnnotation({ filePath, id: 'missing' })).toEqual({ removed: false });
+    expect(await listAnnotations({ filePath })).toHaveLength(1);
+  });
+
+  it('rejects invalid JSON instead of overwriting the sidecar', async () => {
+    const filePath = path.join(tempDir, 'bad.epub');
+    await fs.writeFile(getAnnotationSidecarPath(filePath), '{ invalid json', 'utf-8');
+
+    await expect(listAnnotations({ filePath })).rejects.toThrow('Invalid annotation sidecar JSON');
+  });
+});

--- a/packages/shared/src/app.ts
+++ b/packages/shared/src/app.ts
@@ -16,6 +16,7 @@ import { Bookshelf } from './controller/Bookshelf';
 import { Config } from './controller/Config';
 import { TTS } from './controller/TTS';
 import { Cache } from './controller/Cache';
+import { Annotations } from './controller/Annotations';
 import { mapRoute } from './decorators';
 
 export interface App {
@@ -41,7 +42,7 @@ export function createApp(params: { configPath: string; defaultConfig?: any; dat
     configPath: params.configPath,
     analyzerManager: params.analyzerManager || createAnalyzerManager(),
 
-    controllers: [ChapterHistory, ResourceHistory, ResourceFavorites, ResourceRule, RuleManager, Bookshelf, Config, TTS, Cache],
+    controllers: [ChapterHistory, ResourceHistory, ResourceFavorites, ResourceRule, RuleManager, Bookshelf, Config, TTS, Cache, Annotations],
 
     updateConfig(data: any) {
       ensureFileSync(app.configPath);

--- a/packages/shared/src/controller/Annotations.ts
+++ b/packages/shared/src/controller/Annotations.ts
@@ -1,0 +1,31 @@
+import { Controller, Post } from '../decorators';
+import type { AnnotationListParams, AnnotationRemoveParams, AnnotationUpsertParams } from '../utils/annotations';
+import { listAnnotations, removeAnnotation, upsertAnnotation } from '../utils/annotations';
+import { BaseController } from './BaseController';
+
+@Controller('/annotations')
+export class Annotations extends BaseController {
+  /**
+   * 读取一本书的 annotations，可按章节过滤。
+   */
+  @Post('list')
+  list(data: AnnotationListParams) {
+    return listAnnotations(data);
+  }
+
+  /**
+   * 新增或更新一个 annotation。
+   */
+  @Post('upsert')
+  upsert(data: AnnotationUpsertParams) {
+    return upsertAnnotation(data);
+  }
+
+  /**
+   * 删除一个 annotation。
+   */
+  @Post('remove')
+  remove(data: AnnotationRemoveParams) {
+    return removeAnnotation(data);
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * as CONSTANTS from './constants';
 export * from './app';
+export * from './utils/annotations';

--- a/packages/shared/src/utils/BookParser/parsers/EPubBookParser.ts
+++ b/packages/shared/src/utils/BookParser/parsers/EPubBookParser.ts
@@ -3,16 +3,21 @@ import type { BookChapter, IBookParser } from '../types';
 import { BaseBookParser } from './BaseBookParser';
 
 export default class EPubBookParser extends BaseBookParser implements IBookParser {
+  /**
+   * 读取 EPUB spine 里的章节列表，并保留章节 href 和 spine 顺序用于 annotation 定位。
+   */
   public getChapter(): Promise<BookChapter[]> {
     return new Promise((resolve, reject) => {
       const book = new EPub(this.filePath);
       book.on('end', () => {
         resolve(
-          book.flow.map((e: any) => {
+          book.flow.map((e: any, spineIndex: number) => {
             return {
               name: e.title || e.id,
               chapterPath: e.id,
-              filePath: this.filePath
+              filePath: this.filePath,
+              chapterHref: e.href,
+              spineIndex
             };
           })
         );
@@ -24,6 +29,9 @@ export default class EPubBookParser extends BaseBookParser implements IBookParse
     });
   }
 
+  /**
+   * 读取指定章节正文，返回可直接渲染的 XHTML body 内容。
+   */
   public getContent(chapterPath: string): Promise<string[]> {
     return new Promise((resolve, reject) => {
       const book = new EPub(this.filePath);

--- a/packages/shared/src/utils/BookParser/types.ts
+++ b/packages/shared/src/utils/BookParser/types.ts
@@ -2,6 +2,8 @@ export interface BookChapter {
   name: string;
   chapterPath: string;
   filePath: string;
+  chapterHref?: string;
+  spineIndex?: number;
 }
 
 export interface IBookParser {

--- a/packages/shared/src/utils/annotations/index.ts
+++ b/packages/shared/src/utils/annotations/index.ts
@@ -1,0 +1,2 @@
+export * from './sidecar';
+export * from './types';

--- a/packages/shared/src/utils/annotations/sidecar.ts
+++ b/packages/shared/src/utils/annotations/sidecar.ts
@@ -1,0 +1,150 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { AnnotationFile, AnnotationListParams, AnnotationRemoveParams, AnnotationUpsertParams, ReaderAnnotation } from './types';
+
+const ANNOTATION_SCHEMA_VERSION = 1;
+const SIDECAR_SUFFIX = '.any-reader.annotations.json';
+
+function splitFilePath(filePath: string) {
+  const lastSlash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+  if (lastSlash < 0) {
+    return {
+      dir: '',
+      separator: path.sep,
+      base: filePath
+    };
+  }
+
+  return {
+    dir: filePath.slice(0, lastSlash),
+    separator: filePath[lastSlash],
+    base: filePath.slice(lastSlash + 1)
+  };
+}
+
+function createEmptyAnnotationFile(filePath: string): AnnotationFile {
+  const { base } = splitFilePath(filePath);
+  return {
+    schemaVersion: ANNOTATION_SCHEMA_VERSION,
+    sourceFile: filePath,
+    sourceName: base,
+    updatedAt: new Date().toISOString(),
+    annotations: []
+  };
+}
+
+async function exists(filePath: string) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function atomicWriteJson(filePath: string, data: AnnotationFile) {
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  const json = `${JSON.stringify(data, null, 2)}\n`;
+  await fs.writeFile(tempPath, json, 'utf-8');
+  await fs.rename(tempPath, filePath);
+}
+
+function assertAnnotationFileShape(data: any, sidecarPath: string): AnnotationFile {
+  if (!data || typeof data !== 'object' || !Array.isArray(data.annotations)) {
+    throw new Error(`Invalid annotation sidecar: ${sidecarPath}`);
+  }
+
+  return {
+    schemaVersion: ANNOTATION_SCHEMA_VERSION,
+    sourceFile: String(data.sourceFile || ''),
+    sourceName: String(data.sourceName || ''),
+    updatedAt: String(data.updatedAt || ''),
+    annotations: data.annotations as ReaderAnnotation[]
+  };
+}
+
+/**
+ * 返回 EPUB 对应的 sidecar 路径，格式为 `<book>.epub.any-reader.annotations.json`。
+ */
+export function getAnnotationSidecarPath(filePath: string) {
+  const { dir, separator, base } = splitFilePath(filePath);
+  const sidecarName = `${base}${SIDECAR_SUFFIX}`;
+  return dir ? `${dir}${separator}${sidecarName}` : sidecarName;
+}
+
+/**
+ * 读取 annotation sidecar；文件不存在时返回空结构，JSON 损坏时抛出错误避免覆盖数据。
+ */
+export async function readAnnotationFile(filePath: string): Promise<AnnotationFile> {
+  const sidecarPath = getAnnotationSidecarPath(filePath);
+  if (!(await exists(sidecarPath))) return createEmptyAnnotationFile(filePath);
+
+  const raw = await fs.readFile(sidecarPath, 'utf-8');
+  try {
+    return assertAnnotationFileShape(JSON.parse(raw), sidecarPath);
+  } catch (error) {
+    if (error instanceof SyntaxError) throw new Error(`Invalid annotation sidecar JSON: ${sidecarPath}`);
+    throw error;
+  }
+}
+
+/**
+ * 写入完整 annotation sidecar，使用临时文件和 rename，避免半写入文件被读取。
+ */
+export async function writeAnnotationFile(filePath: string, data: AnnotationFile): Promise<AnnotationFile> {
+  const sidecarPath = getAnnotationSidecarPath(filePath);
+  const parentDir = splitFilePath(sidecarPath).dir;
+  if (parentDir) await fs.mkdir(parentDir, { recursive: true });
+
+  const nextData: AnnotationFile = {
+    ...data,
+    schemaVersion: ANNOTATION_SCHEMA_VERSION,
+    sourceFile: filePath,
+    sourceName: splitFilePath(filePath).base,
+    updatedAt: new Date().toISOString()
+  };
+  await atomicWriteJson(sidecarPath, nextData);
+  return nextData;
+}
+
+/**
+ * 按书和可选章节读取 annotations。
+ */
+export async function listAnnotations(params: AnnotationListParams): Promise<ReaderAnnotation[]> {
+  const data = await readAnnotationFile(params.filePath);
+  if (!params.chapterPath) return data.annotations;
+  return data.annotations.filter((annotation) => annotation.target.chapterPath === params.chapterPath);
+}
+
+/**
+ * 新增或更新一个 annotation，并刷新 createdAt/updatedAt。
+ */
+export async function upsertAnnotation(params: AnnotationUpsertParams): Promise<ReaderAnnotation> {
+  const data = await readAnnotationFile(params.filePath);
+  const now = new Date().toISOString();
+  const existing = data.annotations.find((annotation) => annotation.id === params.annotation.id);
+  const nextAnnotation: ReaderAnnotation = {
+    ...params.annotation,
+    createdAt: existing?.createdAt || params.annotation.createdAt || now,
+    updatedAt: now
+  };
+
+  data.annotations = existing
+    ? data.annotations.map((annotation) => (annotation.id === nextAnnotation.id ? nextAnnotation : annotation))
+    : [...data.annotations, nextAnnotation];
+
+  await writeAnnotationFile(params.filePath, data);
+  return nextAnnotation;
+}
+
+/**
+ * 删除指定 annotation，返回是否真的删除了数据。
+ */
+export async function removeAnnotation(params: AnnotationRemoveParams): Promise<{ removed: boolean }> {
+  const data = await readAnnotationFile(params.filePath);
+  const previousLength = data.annotations.length;
+  data.annotations = data.annotations.filter((annotation) => annotation.id !== params.id);
+  const removed = data.annotations.length !== previousLength;
+  if (removed) await writeAnnotationFile(params.filePath, data);
+  return { removed };
+}

--- a/packages/shared/src/utils/annotations/types.ts
+++ b/packages/shared/src/utils/annotations/types.ts
@@ -1,0 +1,92 @@
+export type ReaderAnnotationKind = 'highlight' | 'text' | 'ink';
+
+export type ReaderAnnotationColor = 'yellow' | 'green' | 'blue' | 'pink' | 'purple';
+
+export interface TextQuoteSelector {
+  type: 'TextQuoteSelector';
+  exact: string;
+  prefix: string;
+  suffix: string;
+}
+
+export interface TextPositionSelector {
+  type: 'TextPositionSelector';
+  start: number;
+  end: number;
+}
+
+export interface CssSelector {
+  type: 'CssSelector';
+  value: string;
+  refinedBy: TextPositionSelector;
+}
+
+export interface AnyReaderDomRangeSelector {
+  type: 'AnyReaderDomRangeSelector';
+  startPath: number[];
+  startOffset: number;
+  endPath: number[];
+  endOffset: number;
+}
+
+export interface ProgressionSelector {
+  type: 'ProgressionSelector';
+  value: number;
+}
+
+export type ReaderAnnotationSelector = TextQuoteSelector | CssSelector | AnyReaderDomRangeSelector | ProgressionSelector;
+
+export interface ReaderAnnotationTarget {
+  source: string;
+  type: 'application/xhtml+xml';
+  filePath: string;
+  chapterPath: string;
+  chapterHref?: string;
+  chapterTitle?: string;
+  selectors: ReaderAnnotationSelector[];
+  orphaned?: boolean;
+}
+
+export interface ReaderAnnotationLLM {
+  sourceFile: string;
+  citation: string;
+  chapterTitle?: string;
+  quote: string;
+  before: string;
+  after: string;
+  note: string;
+}
+
+export interface ReaderAnnotation {
+  id: string;
+  kind: ReaderAnnotationKind;
+  color: ReaderAnnotationColor;
+  note: string;
+  createdAt: string;
+  updatedAt: string;
+  target: ReaderAnnotationTarget;
+  llm: ReaderAnnotationLLM;
+}
+
+export interface AnnotationFile {
+  schemaVersion: 1;
+  sourceFile: string;
+  sourceName: string;
+  updatedAt: string;
+  annotations: ReaderAnnotation[];
+}
+
+export interface AnnotationListParams {
+  filePath: string;
+  chapterPath?: string;
+}
+
+export interface AnnotationUpsertParams {
+  filePath: string;
+  annotation: ReaderAnnotation;
+}
+
+export interface AnnotationRemoveParams {
+  filePath: string;
+  id: string;
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -120,7 +120,11 @@
             "type": "string",
             "enum": [
               "Off",
-              "Debug"
+              "Error",
+              "Warn",
+              "Info",
+              "Debug",
+              "Trace"
             ],
             "default": "Off",
             "description": "修改此配置后需要重启VSCode才会生效"

--- a/packages/vscode/src/Logger.ts
+++ b/packages/vscode/src/Logger.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { LogLevel } from '@any-reader/core';
 
 const outputChannel = vscode.window.createOutputChannel('any-reader');
 
@@ -7,22 +8,52 @@ function formatMsg(message: string, type: string) {
 }
 
 export class Logger {
-  log(message: string): void {
-    typeof message === 'string' && outputChannel.appendLine(formatMsg(message, 'log'));
+  private logLevel: LogLevel;
+
+  constructor(logLevel = LogLevel.Off) {
+    this.logLevel = logLevel;
   }
-  trace(message: any): void {
-    typeof message === 'string' && outputChannel.appendLine(formatMsg(message, 'trace'));
+
+  setLevel(logLevel: LogLevel) {
+    this.logLevel = logLevel;
   }
-  debug(message: any): void {
-    typeof message === 'string' && outputChannel.appendLine(formatMsg(message, 'debug'));
+
+  private shouldLog(level: LogLevel) {
+    return this.logLevel >= level;
   }
-  info(message: any): void {
-    typeof message === 'string' && outputChannel.appendLine(formatMsg(message, 'info'));
+
+  private stringify(message: any, data?: any) {
+    const text = typeof message === 'string' ? message : JSON.stringify(message);
+    if (typeof data === 'undefined') return text;
+    return `${text} ${typeof data === 'string' ? data : JSON.stringify(data)}`;
   }
-  warn(message: any): void {
-    typeof message === 'string' && outputChannel.appendLine(formatMsg(message, 'warn'));
+
+  write(level: keyof typeof LogLevel | 'log', message: any, data?: any): void {
+    const method = level === 'log' ? 'log' : level.toLowerCase();
+    if (method === 'trace') this.trace(message, data);
+    else if (method === 'debug') this.debug(message, data);
+    else if (method === 'info') this.info(message, data);
+    else if (method === 'warn') this.warn(message, data);
+    else if (method === 'error' || method === 'fatal') this.error(message, data);
+    else this.log(message, data);
   }
-  error(message: any): void {
-    typeof message === 'string' && outputChannel.appendLine(formatMsg(message, 'error'));
+
+  log(message: any, data?: any): void {
+    this.shouldLog(LogLevel.Info) && outputChannel.appendLine(formatMsg(this.stringify(message, data), 'log'));
+  }
+  trace(message: any, data?: any): void {
+    this.shouldLog(LogLevel.Trace) && outputChannel.appendLine(formatMsg(this.stringify(message, data), 'trace'));
+  }
+  debug(message: any, data?: any): void {
+    this.shouldLog(LogLevel.Debug) && outputChannel.appendLine(formatMsg(this.stringify(message, data), 'debug'));
+  }
+  info(message: any, data?: any): void {
+    this.shouldLog(LogLevel.Info) && outputChannel.appendLine(formatMsg(this.stringify(message, data), 'info'));
+  }
+  warn(message: any, data?: any): void {
+    this.shouldLog(LogLevel.Warn) && outputChannel.appendLine(formatMsg(this.stringify(message, data), 'warn'));
+  }
+  error(message: any, data?: any): void {
+    this.shouldLog(LogLevel.Error) && outputChannel.appendLine(formatMsg(this.stringify(message, data), 'error'));
   }
 }

--- a/packages/vscode/src/webview/WebviewEvent.ts
+++ b/packages/vscode/src/webview/WebviewEvent.ts
@@ -14,6 +14,7 @@ import { Logger } from '../Logger';
 export class WebviewEvent {
   private _pm!: EasyPostMessage;
   private _extensionPath: string;
+  private _logger = new Logger();
 
   get pm() {
     return this._pm;
@@ -22,13 +23,15 @@ export class WebviewEvent {
   constructor(webview: vscode.Webview, extensionPath: string) {
     this._pm = new EasyPostMessage(createAdapter(webview));
     this._pm.answer('post@vscode/executeCommand', this.executeCommand.bind(this));
+    this._pm.answer('post@vscode/log', this.webviewLog.bind(this));
     this._extensionPath = extensionPath;
   }
 
   async useApi() {
     const logLevelConfig = vscode.workspace.getConfiguration('any-reader').get('logLevel') as keyof typeof LogLevel;
     const logLevel = logLevelConfig ? (LogLevel[logLevelConfig] ?? LogLevel.Off) : LogLevel.Off;
-    const logger = new Logger();
+    const logger = new Logger(logLevel);
+    this._logger = logger;
     logger.info(`[logLevel] ${logLevel}`);
 
     const app = createApp({
@@ -56,6 +59,10 @@ export class WebviewEvent {
   private executeCommand({ command, data }: any) {
     const args = Array.isArray(data) ? data : typeof data === 'object' ? [data] : [];
     vscode.commands.executeCommand(command, ...args);
+  }
+
+  private webviewLog({ level = 'Debug', scope = 'webview', message = '', data }: any) {
+    this._logger.write(level, `[${scope}] ${message}`, data);
   }
 }
 

--- a/packages/web/__test__/browser/annotations.test.ts
+++ b/packages/web/__test__/browser/annotations.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import type { ReaderAnnotation } from '../../../shared/src/utils/annotations/types';
+import {
+  createAnnotationFromSelection,
+  rangeOverlapsAnnotation,
+  renderAnnotations,
+  restoreAnnotationRange
+} from '../../src/pages/vscode/content/annotations';
+
+function mountContent(html = '<div class="center-row" data-idx="0">Hello brave new world.</div>') {
+  document.body.innerHTML = `<div id="text-container">${html}</div>`;
+  return document.querySelector('#text-container') as HTMLElement;
+}
+
+function selectText(textNode: Text, start: number, end: number) {
+  const range = document.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, end);
+  const selection = window.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return selection;
+}
+
+function createMountedAnnotation() {
+  const root = mountContent();
+  const textNode = root.querySelector('.center-row')!.firstChild as Text;
+  const selection = selectText(textNode, 6, 11);
+  const annotation = createAnnotationFromSelection({
+    root,
+    selection,
+    filePath: '/books/demo.epub',
+    chapterPath: 'chapter-1',
+    chapterHref: 'OEBPS/chapter-1.xhtml',
+    chapterTitle: 'Chapter 1',
+    color: 'yellow',
+    note: 'memo'
+  })!;
+
+  return { root, annotation };
+}
+
+describe('VSCode EPUB annotations DOM helpers', () => {
+  it('creates an LLM-friendly annotation from a DOM selection', () => {
+    const { annotation } = createMountedAnnotation();
+
+    expect(annotation.llm).toMatchObject({
+      sourceFile: '/books/demo.epub',
+      chapterTitle: 'Chapter 1',
+      quote: 'brave',
+      note: 'memo'
+    });
+    expect(annotation.target.selectors.map((selector) => selector.type)).toEqual([
+      'TextQuoteSelector',
+      'CssSelector',
+      'AnyReaderDomRangeSelector',
+      'ProgressionSelector'
+    ]);
+  });
+
+  it('restores and renders the highlight after the HTML is reloaded', () => {
+    const { annotation } = createMountedAnnotation();
+    const root = mountContent();
+
+    const orphaned = renderAnnotations({
+      root,
+      annotations: [annotation],
+      onClick: () => {}
+    });
+
+    expect(orphaned).toEqual([]);
+    expect(root.querySelector('.ar-annotation')?.textContent).toBe('brave');
+  });
+
+  it('falls back to TextQuoteSelector when structural selectors fail', () => {
+    const { annotation } = createMountedAnnotation();
+    const fallbackAnnotation: ReaderAnnotation = {
+      ...annotation,
+      target: {
+        ...annotation.target,
+        selectors: annotation.target.selectors.map((selector) => {
+          if (selector.type === 'AnyReaderDomRangeSelector') {
+            return { ...selector, startPath: [99], endPath: [99] };
+          }
+          if (selector.type === 'CssSelector') {
+            return { ...selector, value: '.missing-row', refinedBy: { ...selector.refinedBy, start: 999, end: 1004 } };
+          }
+          return selector;
+        })
+      }
+    };
+    const root = mountContent('<div class="center-row" data-idx="0">Hello brave new world!</div>');
+
+    expect(restoreAnnotationRange(root, fallbackAnnotation)?.toString()).toBe('brave');
+  });
+
+  it('detects overlapping selections', () => {
+    const { annotation } = createMountedAnnotation();
+    const root = mountContent();
+    renderAnnotations({
+      root,
+      annotations: [annotation],
+      onClick: () => {}
+    });
+
+    const markText = root.querySelector('.ar-annotation')!.firstChild as Text;
+    const range = selectText(markText, 1, 3).getRangeAt(0);
+
+    expect(rangeOverlapsAnnotation(root, range)).toBe(true);
+  });
+
+  it('emits hover callbacks from rendered highlights', () => {
+    const { annotation } = createMountedAnnotation();
+    const root = mountContent();
+    const events: string[] = [];
+    renderAnnotations({
+      root,
+      annotations: [annotation],
+      onClick: () => {},
+      onHoverStart: (item) => events.push(`start:${item.id}`),
+      onHoverMove: (item) => events.push(`move:${item.id}`),
+      onHoverEnd: (item) => events.push(`end:${item.id}`)
+    });
+
+    const mark = root.querySelector('.ar-annotation')!;
+    mark.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+    mark.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+    mark.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
+
+    expect(events).toEqual([`start:${annotation.id}`, `move:${annotation.id}`, `end:${annotation.id}`]);
+  });
+});

--- a/packages/web/src/api/index.ts
+++ b/packages/web/src/api/index.ts
@@ -1,5 +1,6 @@
 export * from './modules/bookshelf';
 export * from './modules/chapter-history';
+export * from './modules/annotations';
 export * from './modules/config';
 export * from './modules/electron';
 export * from './modules/resource-favorites';

--- a/packages/web/src/api/modules/annotations.ts
+++ b/packages/web/src/api/modules/annotations.ts
@@ -1,0 +1,43 @@
+/**
+ * 阅读批注。
+ */
+import type {
+  AnnotationListParams,
+  AnnotationRemoveParams,
+  AnnotationUpsertParams,
+  ReaderAnnotation
+} from '../../../../shared/src/utils/annotations/types';
+import { request } from '@/utils/request';
+
+/**
+ * 读取一本书的 annotations，可按章节过滤。
+ */
+export function listAnnotations(data: AnnotationListParams) {
+  return request<ReaderAnnotation[]>({
+    method: 'post',
+    url: 'annotations/list',
+    data
+  });
+}
+
+/**
+ * 新增或更新一个 annotation。
+ */
+export function upsertAnnotation(data: AnnotationUpsertParams) {
+  return request<ReaderAnnotation>({
+    method: 'post',
+    url: 'annotations/upsert',
+    data
+  });
+}
+
+/**
+ * 删除一个 annotation。
+ */
+export function removeAnnotation(data: AnnotationRemoveParams) {
+  return request<{ removed: boolean }>({
+    method: 'post',
+    url: 'annotations/remove',
+    data
+  });
+}

--- a/packages/web/src/api/modules/vsc.ts
+++ b/packages/web/src/api/modules/vsc.ts
@@ -11,3 +11,12 @@ export function executeCommand(data: any) {
     data
   });
 }
+
+export function vscodeLog(data: any) {
+  return request({
+    method: 'post',
+    url: 'vscode/log',
+    data,
+    showMsg: false
+  });
+}

--- a/packages/web/src/pages/vscode/content/annotations.ts
+++ b/packages/web/src/pages/vscode/content/annotations.ts
@@ -1,0 +1,360 @@
+import { v4 as uuidV4 } from 'uuid';
+import type {
+  AnyReaderDomRangeSelector,
+  CssSelector,
+  ProgressionSelector,
+  ReaderAnnotation,
+  ReaderAnnotationColor,
+  ReaderAnnotationSelector,
+  TextQuoteSelector
+} from '../../../../../shared/src/utils/annotations/types';
+
+const ANNOTATION_CLASS = 'ar-annotation';
+const CONTEXT_LENGTH = 60;
+
+interface SelectionAnnotationOptions {
+  root: HTMLElement;
+  selection: Selection;
+  filePath: string;
+  chapterPath: string;
+  chapterHref?: string;
+  chapterTitle?: string;
+  color: ReaderAnnotationColor;
+  note: string;
+}
+
+interface RenderAnnotationOptions {
+  root: HTMLElement;
+  annotations: ReaderAnnotation[];
+  onClick: (annotation: ReaderAnnotation, event: MouseEvent) => void;
+  onHoverStart?: (annotation: ReaderAnnotation, event: MouseEvent) => void;
+  onHoverMove?: (annotation: ReaderAnnotation, event: MouseEvent) => void;
+  onHoverEnd?: (annotation: ReaderAnnotation, event: MouseEvent) => void;
+}
+
+interface TextPosition {
+  start: number;
+  end: number;
+}
+
+function getTextNodes(root: Node) {
+  if (root.nodeType === Node.TEXT_NODE) return [root as Text];
+
+  const textNodes: Text[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let node = walker.nextNode();
+  while (node) {
+    textNodes.push(node as Text);
+    node = walker.nextNode();
+  }
+  return textNodes;
+}
+
+function getNodePath(root: Node, node: Node) {
+  const path: number[] = [];
+  let current: Node | null = node;
+  while (current && current !== root) {
+    const parent = current.parentNode;
+    if (!parent) return [];
+    path.unshift(Array.from(parent.childNodes).indexOf(current));
+    current = parent;
+  }
+  return current === root ? path : [];
+}
+
+function getNodeByPath(root: Node, nodePath: number[]) {
+  let current: Node | null = root;
+  for (const index of nodePath) {
+    current = current?.childNodes[index] || null;
+    if (!current) return null;
+  }
+  return current;
+}
+
+function getTextPosition(root: Node, range: Range): TextPosition | null {
+  let cursor = 0;
+  let start: number | undefined;
+  let end: number | undefined;
+
+  for (const textNode of getTextNodes(root)) {
+    const length = textNode.data.length;
+    if (textNode === range.startContainer) start = cursor + range.startOffset;
+    if (textNode === range.endContainer) end = cursor + range.endOffset;
+    cursor += length;
+  }
+
+  if (typeof start === 'undefined' || typeof end === 'undefined' || start > end) return null;
+  return { start, end };
+}
+
+function rangeFromTextPosition(root: Node, start: number, end: number) {
+  const range = document.createRange();
+  let cursor = 0;
+  let started = false;
+
+  for (const textNode of getTextNodes(root)) {
+    const nextCursor = cursor + textNode.data.length;
+    if (!started && start <= nextCursor) {
+      range.setStart(textNode, Math.max(0, start - cursor));
+      started = true;
+    }
+    if (started && end <= nextCursor) {
+      range.setEnd(textNode, Math.max(0, end - cursor));
+      return range;
+    }
+    cursor = nextCursor;
+  }
+
+  return null;
+}
+
+function getClosestContentRow(node: Node | null) {
+  const element = node instanceof Element ? node : node?.parentElement;
+  return element?.closest('.center-row') as HTMLElement | null;
+}
+
+function getCssTarget(root: HTMLElement, range: Range) {
+  const startRow = getClosestContentRow(range.startContainer);
+  const endRow = getClosestContentRow(range.endContainer);
+  if (startRow && startRow === endRow) return startRow;
+  return root;
+}
+
+function getCssSelector(root: HTMLElement, target: HTMLElement) {
+  if (target === root) return '#text-container';
+  const rowIndex = target.dataset.idx;
+  return typeof rowIndex !== 'undefined' ? `[data-idx="${rowIndex}"]` : '#text-container';
+}
+
+function getSelector<T extends ReaderAnnotationSelector>(selectors: ReaderAnnotationSelector[], type: T['type']): T | undefined {
+  return selectors.find((selector) => selector.type === type) as T | undefined;
+}
+
+function getQuoteRange(root: HTMLElement, quoteSelector: TextQuoteSelector) {
+  const text = root.textContent || '';
+  const matches: number[] = [];
+  let cursor = text.indexOf(quoteSelector.exact);
+  while (cursor >= 0) {
+    matches.push(cursor);
+    cursor = text.indexOf(quoteSelector.exact, cursor + quoteSelector.exact.length);
+  }
+
+  const index =
+    matches.find((match) => {
+      const prefix = text.slice(Math.max(0, match - quoteSelector.prefix.length), match);
+      const suffix = text.slice(match + quoteSelector.exact.length, match + quoteSelector.exact.length + quoteSelector.suffix.length);
+      return prefix === quoteSelector.prefix && suffix === quoteSelector.suffix;
+    }) ?? matches[0];
+
+  if (typeof index === 'undefined') return null;
+  return rangeFromTextPosition(root, index, index + quoteSelector.exact.length);
+}
+
+function restoreDomRange(root: HTMLElement, selector: AnyReaderDomRangeSelector) {
+  const startNode = getNodeByPath(root, selector.startPath);
+  const endNode = getNodeByPath(root, selector.endPath);
+  if (!startNode || !endNode) return null;
+
+  try {
+    const range = document.createRange();
+    range.setStart(startNode, selector.startOffset);
+    range.setEnd(endNode, selector.endOffset);
+    return range;
+  } catch {
+    return null;
+  }
+}
+
+function restoreTextPositionRange(root: HTMLElement, selector: CssSelector) {
+  const scope = root.querySelector(selector.value) || root;
+  return rangeFromTextPosition(scope, selector.refinedBy.start, selector.refinedBy.end);
+}
+
+function wrapRange(annotation: ReaderAnnotation, range: Range, options: RenderAnnotationOptions) {
+  const textNodes = getTextNodes(range.commonAncestorContainer)
+    .filter((node) => {
+      try {
+        return range.intersectsNode(node);
+      } catch {
+        return false;
+      }
+    })
+    .reverse();
+
+  for (const textNode of textNodes) {
+    const startOffset = textNode === range.startContainer ? range.startOffset : 0;
+    const endOffset = textNode === range.endContainer ? range.endOffset : textNode.data.length;
+    if (startOffset >= endOffset) continue;
+
+    const nodeRange = document.createRange();
+    nodeRange.setStart(textNode, startOffset);
+    nodeRange.setEnd(textNode, endOffset);
+
+    const mark = document.createElement('span');
+    mark.className = `${ANNOTATION_CLASS} ${ANNOTATION_CLASS}--${annotation.color}`;
+    mark.dataset.annotationId = annotation.id;
+    mark.setAttribute('aria-label', annotation.note || annotation.llm.quote);
+    mark.addEventListener('click', (event) => {
+      event.stopPropagation();
+      options.onClick(annotation, event);
+    });
+    mark.addEventListener('mouseenter', (event) => {
+      options.onHoverStart?.(annotation, event);
+    });
+    mark.addEventListener('mousemove', (event) => {
+      options.onHoverMove?.(annotation, event);
+    });
+    mark.addEventListener('mouseleave', (event) => {
+      options.onHoverEnd?.(annotation, event);
+    });
+    nodeRange.surroundContents(mark);
+  }
+}
+
+/**
+ * 判断当前页面是否应该启用 EPUB annotations。
+ */
+export function isEpubAnnotationEnabled(filePath?: string, ruleId?: string) {
+  return !!filePath && !ruleId && /\.epub$/i.test(filePath);
+}
+
+/**
+ * 从当前 DOM selection 生成一个可持久化、对 LLM 友好的 annotation。
+ */
+export function createAnnotationFromSelection(options: SelectionAnnotationOptions): ReaderAnnotation | null {
+  const range = options.selection.rangeCount ? options.selection.getRangeAt(0).cloneRange() : null;
+  if (!range || range.collapsed || !options.root.contains(range.commonAncestorContainer)) return null;
+
+  const quote = options.selection.toString();
+  if (!quote.trim()) return null;
+
+  const rootPosition = getTextPosition(options.root, range);
+  if (!rootPosition) return null;
+
+  const cssTarget = getCssTarget(options.root, range);
+  const cssPosition = getTextPosition(cssTarget, range);
+  if (!cssPosition) return null;
+
+  const rootText = options.root.textContent || '';
+  const prefix = rootText.slice(Math.max(0, rootPosition.start - CONTEXT_LENGTH), rootPosition.start);
+  const suffix = rootText.slice(rootPosition.end, rootPosition.end + CONTEXT_LENGTH);
+  const source = options.chapterHref || options.chapterPath;
+  const now = new Date().toISOString();
+  const selectors: ReaderAnnotationSelector[] = [
+    {
+      type: 'TextQuoteSelector',
+      exact: quote,
+      prefix,
+      suffix
+    },
+    {
+      type: 'CssSelector',
+      value: getCssSelector(options.root, cssTarget),
+      refinedBy: {
+        type: 'TextPositionSelector',
+        start: cssPosition.start,
+        end: cssPosition.end
+      }
+    },
+    {
+      type: 'AnyReaderDomRangeSelector',
+      startPath: getNodePath(options.root, range.startContainer),
+      startOffset: range.startOffset,
+      endPath: getNodePath(options.root, range.endContainer),
+      endOffset: range.endOffset
+    },
+    {
+      type: 'ProgressionSelector',
+      value: rootText.length ? rootPosition.start / rootText.length : 0
+    } satisfies ProgressionSelector
+  ];
+
+  return {
+    id: uuidV4(),
+    kind: 'highlight',
+    color: options.color,
+    note: options.note,
+    createdAt: now,
+    updatedAt: now,
+    target: {
+      source,
+      type: 'application/xhtml+xml',
+      filePath: options.filePath,
+      chapterPath: options.chapterPath,
+      chapterHref: options.chapterHref,
+      chapterTitle: options.chapterTitle,
+      selectors
+    },
+    llm: {
+      sourceFile: options.filePath,
+      citation: `${options.chapterTitle || options.chapterPath}: ${quote}`,
+      chapterTitle: options.chapterTitle,
+      quote,
+      before: prefix,
+      after: suffix,
+      note: options.note
+    }
+  };
+}
+
+/**
+ * 判断当前 selection 是否和已有高亮重叠。
+ */
+export function rangeOverlapsAnnotation(root: HTMLElement, range: Range) {
+  return Array.from(root.querySelectorAll(`.${ANNOTATION_CLASS}`)).some((element) => {
+    try {
+      return range.intersectsNode(element);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * 移除当前页面中渲染出来的 annotation wrapper，恢复原始文本节点结构。
+ */
+export function clearRenderedAnnotations(root: HTMLElement) {
+  for (const mark of Array.from(root.querySelectorAll(`.${ANNOTATION_CLASS}`))) {
+    const parent = mark.parentNode;
+    if (!parent) continue;
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+    parent.removeChild(mark);
+    parent.normalize();
+  }
+}
+
+/**
+ * 按 DomRange -> TextPosition -> TextQuote 的顺序恢复 annotation range。
+ */
+export function restoreAnnotationRange(root: HTMLElement, annotation: ReaderAnnotation) {
+  const selectors = annotation.target.selectors;
+  const domSelector = getSelector<AnyReaderDomRangeSelector>(selectors, 'AnyReaderDomRangeSelector');
+  const cssSelector = getSelector<CssSelector>(selectors, 'CssSelector');
+  const quoteSelector = getSelector<TextQuoteSelector>(selectors, 'TextQuoteSelector');
+
+  return (
+    (domSelector && restoreDomRange(root, domSelector)) ||
+    (cssSelector && restoreTextPositionRange(root, cssSelector)) ||
+    (quoteSelector && getQuoteRange(root, quoteSelector)) ||
+    null
+  );
+}
+
+/**
+ * 在阅读页渲染 annotations，返回无法恢复位置的 annotation ids。
+ */
+export function renderAnnotations(options: RenderAnnotationOptions) {
+  const orphanedIds: string[] = [];
+  clearRenderedAnnotations(options.root);
+
+  for (const annotation of options.annotations) {
+    const range = restoreAnnotationRange(options.root, annotation);
+    if (!range) {
+      orphanedIds.push(annotation.id);
+      continue;
+    }
+    wrapRange(annotation, range, options);
+  }
+
+  return orphanedIds;
+}

--- a/packages/web/src/pages/vscode/content/index.vue
+++ b/packages/web/src/pages/vscode/content/index.vue
@@ -13,6 +13,7 @@
         fontSize: settingStore.data.readStyle.fontSize + 'px',
         letterSpacing: settingStore.data.readStyle.letterSpacing + 'px'
       }"
+      @mouseup="handleSelectionMouseUp"
     >
       <template v-if="contentType === ContentType.MANGA">
         <img v-for="(row, idx) in content" :key="idx" class="center-row" :data-idx="idx" :src="row" />
@@ -26,6 +27,54 @@
         <div class="cursor-pointer hover:op-70" :title="readStore.title" @click="init(true)">重载</div>
         <div v-if="nextChapter" class="cursor-pointer hover:op-70" :title="readStore.nextTitle" @click="onNextChapter">下一章</div>
       </div>
+    </div>
+
+    <div
+      v-if="annotationEnabled && annotationMenu.visible"
+      class="annotation-menu"
+      :style="{ left: annotationMenu.x + 'px', top: annotationMenu.y + 'px' }"
+      @mousedown.stop
+    >
+      <div class="annotation-menu__colors">
+        <button
+          v-for="color in annotationColors"
+          :key="color"
+          class="annotation-menu__swatch"
+          :class="[`annotation-menu__swatch--${color}`, { 'annotation-menu__swatch--active': annotationMenu.color === color }]"
+          :title="color"
+          @mousedown.prevent
+          @click="annotationMenu.editingId ? (annotationMenu.color = color) : applySelectionAnnotation(color)"
+        ></button>
+      </div>
+
+      <template v-if="annotationMenu.editingId || annotationMenu.noteMode">
+        <textarea ref="annotationNoteRef" v-model="annotationMenu.note" class="annotation-menu__note" rows="3" placeholder="批注"></textarea>
+      </template>
+
+      <div class="annotation-menu__actions">
+        <template v-if="annotationMenu.editingId">
+          <button class="annotation-menu__button" @mousedown.prevent @click="saveAnnotationEdit">保存</button>
+          <button class="annotation-menu__button" @mousedown.prevent @click="deleteAnnotation">删除</button>
+        </template>
+        <template v-else>
+          <button v-if="!annotationMenu.noteMode" class="annotation-menu__button" @mousedown.prevent @click="openSelectionNote">批注</button>
+          <button v-else class="annotation-menu__button" @mousedown.prevent @click="applySelectionAnnotation(annotationMenu.color)">保存</button>
+        </template>
+      </div>
+    </div>
+
+    <div
+      v-if="annotationEnabled && annotationHover.visible && annotationHover.annotation && !annotationMenu.visible"
+      class="annotation-hover"
+      :style="{ left: annotationHover.x + 'px', top: annotationHover.y + 'px' }"
+    >
+      <div class="annotation-hover__header">
+        <span class="annotation-hover__swatch" :class="`annotation-hover__swatch--${annotationHover.annotation.color}`"></span>
+        <span class="annotation-hover__title">{{ annotationHover.annotation.target.chapterTitle || readStore.title || '批注' }}</span>
+      </div>
+      <div class="annotation-hover__quote">{{ annotationHover.annotation.llm.quote }}</div>
+      <div v-if="annotationHover.annotation.note" class="annotation-hover__note">{{ annotationHover.annotation.note }}</div>
+      <div v-else class="annotation-hover__empty">无批注文本</div>
     </div>
 
     <div class="topbar absolute left-0 top-0 h-30 w-full px-10">
@@ -50,18 +99,352 @@
 </template>
 
 <script setup lang="ts">
+import { message } from 'ant-design-vue';
 import { ContentType } from '@any-reader/rule-utils';
+import type { ReaderAnnotation, ReaderAnnotationColor } from '../../../../../shared/src/utils/annotations/types';
+import { listAnnotations, removeAnnotation, upsertAnnotation } from '@/api/modules/annotations';
 import { useContent, useTheme } from '@/pages/common/content';
+import { useChaptersStore } from '@/stores/chapters';
 import { useReadStore } from '@/stores/read';
+import { vscodeLog } from '@/api/modules/vsc';
+import { createAnnotationFromSelection, isEpubAnnotationEnabled, rangeOverlapsAnnotation, renderAnnotations } from './annotations';
 
 const contentRef = ref();
+const annotationNoteRef = ref<HTMLTextAreaElement>();
 
 const readStore = useReadStore();
+const chaptersStore = useChaptersStore();
+const route = useRoute();
 
 const { content, contentType, settingStore, lastChapter, nextChapter, onPageUp, onPageDown, onPrevChapter, onNextChapter, loading, init } =
   useContent(contentRef);
 
 useTheme(contentRef);
+
+const annotationColors: ReaderAnnotationColor[] = ['yellow', 'green', 'blue', 'pink', 'purple'];
+const annotations = ref<ReaderAnnotation[]>([]);
+let selectedAnnotationRange: Range | null = null;
+const annotationHover = reactive<{
+  visible: boolean;
+  x: number;
+  y: number;
+  annotation: ReaderAnnotation | null;
+}>({
+  visible: false,
+  x: 0,
+  y: 0,
+  annotation: null
+});
+const annotationMenu = reactive({
+  visible: false,
+  x: 0,
+  y: 0,
+  color: 'yellow' as ReaderAnnotationColor,
+  note: '',
+  noteMode: false,
+  editingId: ''
+});
+
+const annotationEnabled = computed(() => isEpubAnnotationEnabled(queryString(route.query.filePath), queryString(route.query.ruleId)));
+
+function logAnnotation(level: 'Trace' | 'Debug' | 'Info' | 'Warn' | 'Error', message: string, data?: any) {
+  vscodeLog({
+    level,
+    scope: 'epub-annotations',
+    message,
+    data
+  }).catch(() => {});
+}
+
+function queryString(value: unknown) {
+  return Array.isArray(value) ? String(value[0] || '') : String(value || '');
+}
+
+function getCurrentChapter() {
+  const chapterPath = queryString(route.query.chapterPath);
+  return chaptersStore.chapters.find((chapter: any) => chapter.chapterPath === chapterPath);
+}
+
+function hideAnnotationMenu() {
+  annotationMenu.visible = false;
+  annotationMenu.noteMode = false;
+  annotationMenu.editingId = '';
+  annotationMenu.note = '';
+  annotationMenu.color = 'yellow';
+  selectedAnnotationRange = null;
+}
+
+function hideAnnotationHover() {
+  annotationHover.visible = false;
+  annotationHover.annotation = null;
+}
+
+function setAnnotationMenuPosition(clientX: number, clientY: number) {
+  const host = contentRef.value?.parentElement as HTMLElement | undefined;
+  if (!host) return;
+  const hostRect = host.getBoundingClientRect();
+  annotationMenu.x = Math.max(8, clientX - hostRect.left);
+  annotationMenu.y = Math.max(8, clientY - hostRect.top - 44);
+}
+
+function setAnnotationHoverPosition(clientX: number, clientY: number) {
+  const host = contentRef.value?.parentElement as HTMLElement | undefined;
+  if (!host) return;
+  const hostRect = host.getBoundingClientRect();
+  annotationHover.x = Math.max(8, Math.min(hostRect.width - 328, clientX - hostRect.left + 12));
+  annotationHover.y = Math.max(8, Math.min(hostRect.height - 180, clientY - hostRect.top + 16));
+}
+
+async function markOrphanedAnnotations(orphanedIds: string[]) {
+  const orphanedSet = new Set(orphanedIds);
+  const filePath = queryString(route.query.filePath);
+  const updates = annotations.value.filter((annotation) => !!annotation.target.orphaned !== orphanedSet.has(annotation.id));
+  if (orphanedIds.length) logAnnotation('Warn', 'mark orphaned annotations', { filePath, orphanedIds });
+
+  await Promise.all(
+    updates.map((annotation) =>
+      upsertAnnotation({
+        filePath,
+        annotation: {
+          ...annotation,
+          target: {
+            ...annotation.target,
+            orphaned: orphanedSet.has(annotation.id)
+          }
+        }
+      }).catch(() => {})
+    )
+  );
+  annotations.value = annotations.value.map((annotation) => ({
+    ...annotation,
+    target: {
+      ...annotation.target,
+      orphaned: orphanedSet.has(annotation.id)
+    }
+  }));
+}
+
+async function renderCurrentAnnotations() {
+  if (!contentRef.value || !annotationEnabled.value) {
+    logAnnotation('Trace', 'skip render annotations', { hasContentRef: !!contentRef.value, annotationEnabled: annotationEnabled.value });
+    return;
+  }
+  logAnnotation('Debug', 'render annotations start', { count: annotations.value.length, chapterPath: queryString(route.query.chapterPath) });
+  const orphanedIds = renderAnnotations({
+    root: contentRef.value,
+    annotations: annotations.value,
+    onClick: showAnnotationEditor,
+    onHoverStart: showAnnotationHover,
+    onHoverMove: moveAnnotationHover,
+    onHoverEnd: hideAnnotationHover
+  });
+  await markOrphanedAnnotations(orphanedIds);
+  logAnnotation('Debug', 'render annotations done', { count: annotations.value.length, orphanedCount: orphanedIds.length });
+}
+
+async function loadCurrentAnnotations() {
+  if (!annotationEnabled.value) {
+    annotations.value = [];
+    logAnnotation('Trace', 'annotations disabled for route', { filePath: route.query.filePath, ruleId: route.query.ruleId });
+    return;
+  }
+
+  const filePath = queryString(route.query.filePath);
+  const chapterPath = queryString(route.query.chapterPath);
+  logAnnotation('Debug', 'load annotations start', { filePath, chapterPath });
+  const res = await listAnnotations({ filePath, chapterPath }).catch(() => null);
+  annotations.value = res?.code === 0 ? res.data : [];
+  if (res?.code !== 0) logAnnotation('Warn', 'load annotations failed', { filePath, chapterPath, response: res });
+  else logAnnotation('Debug', 'load annotations done', { count: annotations.value.length, filePath, chapterPath });
+  await nextTick();
+  await renderCurrentAnnotations();
+}
+
+function handleSelectionMouseUp() {
+  if (!annotationEnabled.value || !contentRef.value) {
+    logAnnotation('Trace', 'selection ignored because annotations are disabled', { annotationEnabled: annotationEnabled.value });
+    return;
+  }
+
+  const selection = window.getSelection();
+  const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+  if (!selection || !range || range.collapsed || !contentRef.value.contains(range.commonAncestorContainer)) {
+    logAnnotation('Trace', 'selection ignored because range is invalid', {
+      hasSelection: !!selection,
+      hasRange: !!range,
+      collapsed: !!range?.collapsed
+    });
+    hideAnnotationMenu();
+    return;
+  }
+
+  if (rangeOverlapsAnnotation(contentRef.value, range)) {
+    message.warning('暂不支持重叠高亮');
+    logAnnotation('Warn', 'selection rejected because it overlaps existing annotation');
+    selection.removeAllRanges();
+    hideAnnotationMenu();
+    return;
+  }
+
+  selectedAnnotationRange = range.cloneRange();
+  hideAnnotationHover();
+  const rect = range.getBoundingClientRect();
+  setAnnotationMenuPosition(rect.left, rect.top);
+  annotationMenu.visible = true;
+  annotationMenu.noteMode = false;
+  annotationMenu.editingId = '';
+  annotationMenu.note = '';
+  logAnnotation('Debug', 'selection menu shown', {
+    textLength: selection.toString().length,
+    chapterPath: queryString(route.query.chapterPath),
+    filePath: queryString(route.query.filePath)
+  });
+}
+
+async function openSelectionNote() {
+  annotationMenu.noteMode = true;
+  logAnnotation('Debug', 'selection note editor opened');
+  await nextTick();
+  annotationNoteRef.value?.focus();
+}
+
+async function applySelectionAnnotation(color: ReaderAnnotationColor) {
+  if (!contentRef.value) return;
+  if (selectedAnnotationRange) {
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(selectedAnnotationRange.cloneRange());
+  }
+
+  const selection = window.getSelection();
+  const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+  if (!selection || !range || range.collapsed) {
+    logAnnotation('Warn', 'save annotation skipped because selection range is missing');
+    return;
+  }
+
+  if (rangeOverlapsAnnotation(contentRef.value, range)) {
+    message.warning('暂不支持重叠高亮');
+    logAnnotation('Warn', 'save annotation rejected because selection overlaps existing annotation');
+    selection.removeAllRanges();
+    hideAnnotationMenu();
+    return;
+  }
+
+  const chapter = getCurrentChapter();
+  const filePath = queryString(route.query.filePath);
+  const chapterPath = queryString(route.query.chapterPath);
+  const annotation = createAnnotationFromSelection({
+    root: contentRef.value,
+    selection,
+    filePath,
+    chapterPath,
+    chapterHref: chapter?.chapterHref,
+    chapterTitle: chapter?.name || readStore.title,
+    color,
+    note: annotationMenu.note
+  });
+  if (!annotation) {
+    logAnnotation('Warn', 'create annotation from selection failed', { filePath, chapterPath });
+    return;
+  }
+
+  logAnnotation('Debug', 'upsert annotation start', {
+    id: annotation.id,
+    color,
+    hasNote: !!annotation.note,
+    quoteLength: annotation.llm.quote.length,
+    filePath,
+    chapterPath
+  });
+  const res = await upsertAnnotation({ filePath, annotation }).catch(() => null);
+  if (res?.code !== 0) {
+    message.warning('批注保存失败');
+    logAnnotation('Error', 'upsert annotation failed', { id: annotation.id, response: res });
+    return;
+  }
+
+  selection.removeAllRanges();
+  hideAnnotationMenu();
+  logAnnotation('Info', 'annotation saved', { id: annotation.id, filePath, chapterPath });
+  await loadCurrentAnnotations();
+}
+
+function showAnnotationEditor(annotation: ReaderAnnotation, event: MouseEvent) {
+  selectedAnnotationRange = null;
+  hideAnnotationHover();
+  setAnnotationMenuPosition(event.clientX, event.clientY);
+  annotationMenu.visible = true;
+  annotationMenu.editingId = annotation.id;
+  annotationMenu.noteMode = true;
+  annotationMenu.note = annotation.note;
+  annotationMenu.color = annotation.color;
+  logAnnotation('Debug', 'existing annotation editor opened', { id: annotation.id, hasNote: !!annotation.note });
+  nextTick(() => annotationNoteRef.value?.focus());
+}
+
+function showAnnotationHover(annotation: ReaderAnnotation, event: MouseEvent) {
+  if (annotationMenu.visible) return;
+  annotationHover.visible = true;
+  annotationHover.annotation = annotation;
+  setAnnotationHoverPosition(event.clientX, event.clientY);
+  logAnnotation('Trace', 'annotation hover shown', { id: annotation.id, hasNote: !!annotation.note });
+}
+
+function moveAnnotationHover(annotation: ReaderAnnotation, event: MouseEvent) {
+  if (!annotationHover.visible || annotationHover.annotation?.id !== annotation.id) return;
+  setAnnotationHoverPosition(event.clientX, event.clientY);
+}
+
+async function saveAnnotationEdit() {
+  const filePath = queryString(route.query.filePath);
+  const annotation = annotations.value.find((item) => item.id === annotationMenu.editingId);
+  if (!annotation) {
+    logAnnotation('Warn', 'save annotation edit skipped because annotation was not found', { id: annotationMenu.editingId });
+    return;
+  }
+
+  const nextAnnotation: ReaderAnnotation = {
+    ...annotation,
+    color: annotationMenu.color,
+    note: annotationMenu.note,
+    llm: {
+      ...annotation.llm,
+      note: annotationMenu.note
+    }
+  };
+  logAnnotation('Debug', 'save annotation edit start', { id: nextAnnotation.id, color: nextAnnotation.color, hasNote: !!nextAnnotation.note });
+  const res = await upsertAnnotation({ filePath, annotation: nextAnnotation }).catch(() => null);
+  if (res?.code !== 0) {
+    message.warning('批注保存失败');
+    logAnnotation('Error', 'save annotation edit failed', { id: nextAnnotation.id, response: res });
+    return;
+  }
+
+  hideAnnotationMenu();
+  logAnnotation('Info', 'annotation edit saved', { id: nextAnnotation.id, filePath });
+  await loadCurrentAnnotations();
+}
+
+async function deleteAnnotation() {
+  const filePath = queryString(route.query.filePath);
+  logAnnotation('Debug', 'delete annotation start', { id: annotationMenu.editingId, filePath });
+  const res = await removeAnnotation({ filePath, id: annotationMenu.editingId }).catch(() => null);
+  if (res?.code !== 0) {
+    message.warning('批注删除失败');
+    logAnnotation('Error', 'delete annotation failed', { id: annotationMenu.editingId, response: res });
+    return;
+  }
+
+  logAnnotation('Info', 'annotation deleted', { id: annotationMenu.editingId, filePath });
+  hideAnnotationMenu();
+  await loadCurrentAnnotations();
+}
+
+watch([content, () => route.query.filePath, () => route.query.chapterPath], () => loadCurrentAnnotations(), {
+  deep: true,
+  flush: 'post'
+});
 </script>
 
 <style scoped>
@@ -99,5 +482,188 @@ useTheme(contentRef);
   margin-bottom: calc(var(--section-spacing) * 1px);
   font-weight: var(--font-weight);
   opacity: var(--text-opacity);
+}
+
+.annotation-menu {
+  position: absolute;
+  z-index: 20;
+  min-width: 190px;
+  border: 1px solid var(--vscode-editorWidget-border);
+  border-radius: 6px;
+  background: var(--vscode-editorWidget-background);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 22%);
+  padding: 8px;
+  text-indent: 0;
+}
+
+.annotation-menu__colors {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.annotation-menu__swatch {
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--vscode-editorWidget-border);
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.annotation-menu__swatch--active {
+  outline: 2px solid var(--vscode-focusBorder);
+  outline-offset: 1px;
+}
+
+.annotation-menu__swatch--yellow {
+  background: #f2c94c;
+}
+
+.annotation-menu__swatch--green {
+  background: #6fcf97;
+}
+
+.annotation-menu__swatch--blue {
+  background: #56ccf2;
+}
+
+.annotation-menu__swatch--pink {
+  background: #ff8fb3;
+}
+
+.annotation-menu__swatch--purple {
+  background: #bb9af7;
+}
+
+.annotation-menu__note {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid var(--vscode-input-border);
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  font-size: 12px;
+  line-height: 1.4;
+  outline: none;
+  padding: 4px 6px;
+}
+
+.annotation-menu__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.annotation-menu__button {
+  border: 1px solid var(--vscode-button-border, transparent);
+  border-radius: 4px;
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 2px 8px;
+}
+
+.annotation-hover {
+  position: absolute;
+  z-index: 19;
+  width: min(320px, calc(100% - 16px));
+  border: 1px solid var(--vscode-editorWidget-border);
+  border-radius: 6px;
+  background: var(--vscode-editorWidget-background);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 22%);
+  color: var(--vscode-editorWidget-foreground);
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 8px;
+  pointer-events: none;
+  text-indent: 0;
+}
+
+.annotation-hover__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.annotation-hover__swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.annotation-hover__swatch--yellow {
+  background: #f2c94c;
+}
+
+.annotation-hover__swatch--green {
+  background: #6fcf97;
+}
+
+.annotation-hover__swatch--blue {
+  background: #56ccf2;
+}
+
+.annotation-hover__swatch--pink {
+  background: #ff8fb3;
+}
+
+.annotation-hover__swatch--purple {
+  background: #bb9af7;
+}
+
+.annotation-hover__title {
+  overflow: hidden;
+  color: var(--vscode-descriptionForeground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.annotation-hover__quote {
+  max-height: 72px;
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+
+.annotation-hover__note {
+  border-top: 1px solid var(--vscode-editorWidget-border);
+  color: var(--vscode-foreground);
+  padding-top: 6px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.annotation-hover__empty {
+  border-top: 1px solid var(--vscode-editorWidget-border);
+  color: var(--vscode-descriptionForeground);
+  padding-top: 6px;
+}
+
+:deep(.ar-annotation) {
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+:deep(.ar-annotation--yellow) {
+  background: rgb(242 201 76 / 45%);
+}
+
+:deep(.ar-annotation--green) {
+  background: rgb(111 207 151 / 38%);
+}
+
+:deep(.ar-annotation--blue) {
+  background: rgb(86 204 242 / 38%);
+}
+
+:deep(.ar-annotation--pink) {
+  background: rgb(255 143 179 / 40%);
+}
+
+:deep(.ar-annotation--purple) {
+  background: rgb(187 154 247 / 38%);
 }
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       husky:
         specifier: ^8.0.3
         version: 8.0.3
+      lint-staged:
+        specifier: 15.2.10
+        version: 15.2.10
       npm-run-all2:
         specifier: ^6.2.3
         version: 6.2.3
@@ -95,7 +98,7 @@ importers:
         version: 4.2.0
       tsup:
         specifier: ^8.3.0
-        version: 8.3.0(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.1)(typescript@5.8.2)
+        version: 8.3.0(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.1)(typescript@5.8.2)(yaml@2.5.1)
       tsx:
         specifier: ^4.19.1
         version: 4.19.1
@@ -442,7 +445,7 @@ importers:
         version: 5.1.6(encoding@0.1.13)
       typeorm:
         specifier: ^0.3.20
-        version: 0.3.20(sql.js@1.11.0)(sqlite3@5.1.6(encoding@0.1.13))(ts-node@10.9.2(@types/node@22.5.5)(typescript@5.8.2))
+        version: 0.3.20(sql.js@1.11.0)(sqlite3@5.1.6(encoding@0.1.13))(ts-node@10.9.2(@types/node@20.16.5)(typescript@5.8.2))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -694,7 +697,7 @@ importers:
         version: 30.0.6
       electron-builder:
         specifier: ^25.0.5
-        version: 25.0.5(electron-builder-squirrel-windows@24.13.3)
+        version: 25.0.5(electron-builder-squirrel-windows@24.13.3(dmg-builder@25.0.5))
       mockjs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1873,55 +1876,46 @@ packages:
     resolution: {integrity: sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.21.2':
     resolution: {integrity: sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.21.2':
     resolution: {integrity: sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.21.2':
     resolution: {integrity: sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
     resolution: {integrity: sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.21.2':
     resolution: {integrity: sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.21.2':
     resolution: {integrity: sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.21.2':
     resolution: {integrity: sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.21.2':
     resolution: {integrity: sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.21.2':
     resolution: {integrity: sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==}
@@ -2336,6 +2330,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unocss/astro@0.63.4':
     resolution: {integrity: sha512-qu1uMDUT8lXU3mm5EjZpnizvjSYtfY0TTDivR5QNm1i3Xd+ErHfdfOpXdJ2mYvxv+X7C570//KUugkTI3Mb3kQ==}
@@ -2805,6 +2800,7 @@ packages:
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.3':
     resolution: {integrity: sha512-W7fOe0N+t2eyL9sjDE+7bBNo/NZg6U6aU0Rp8wwQV8TRkzLnX13SvROoyJMAH0Kcm9G1DX9b1XI4LxwKxowsXw==}
@@ -2885,6 +2881,10 @@ packages:
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3072,6 +3072,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
@@ -3336,6 +3337,10 @@ packages:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
@@ -3352,6 +3357,10 @@ packages:
   cli-truncate@2.1.0:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
     engines: {node: '>=8'}
+
+  cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -4096,6 +4105,10 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
@@ -4469,6 +4482,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
@@ -4522,16 +4539,17 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -4825,6 +4843,14 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-generator-function@1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
     engines: {node: '>= 0.4'}
@@ -5054,6 +5080,7 @@ packages:
   koa-router@12.0.1:
     resolution: {integrity: sha512-gaDdj3GtzoLoeosacd50kBBTnnh3B9AYxDThQUo4sfUyXdOhY6ku1qyZKW88tQCRgc3Sw6ChXYXWZwwgjOxE0w==}
     engines: {node: '>= 12'}
+    deprecated: 'Please use @koa/router instead, starting from v9! '
 
   koa-send@5.0.1:
     resolution: {integrity: sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==}
@@ -5104,6 +5131,15 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lint-staged@15.2.10:
+    resolution: {integrity: sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
+  listr2@8.2.5:
+    resolution: {integrity: sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==}
+    engines: {node: '>=18.0.0'}
 
   lit-element@4.1.1:
     resolution: {integrity: sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==}
@@ -5186,6 +5222,10 @@ packages:
   log-symbols@5.1.0:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
     engines: {node: '>=12'}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
 
   log4js@6.9.1:
     resolution: {integrity: sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==}
@@ -5422,6 +5462,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
@@ -5604,6 +5648,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
@@ -5737,8 +5782,13 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   oniguruma-to-js@0.4.3:
     resolution: {integrity: sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==}
+    deprecated: use oniguruma-to-es instead
 
   only@0.0.2:
     resolution: {integrity: sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==}
@@ -6170,6 +6220,7 @@ packages:
   prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -6255,6 +6306,7 @@ packages:
   puppeteer@23.5.3:
     resolution: {integrity: sha512-FghmfBsr/UUpe48OiCg1gV3W4vVfQJKjQehbF07SjnQvEpWcvPTah1nykfGWdOQQ1ydJPIXcajzWN7fliCU3zw==}
     engines: {node: '>=18'}
+    deprecated: < 24.15.0 is no longer supported
     hasBin: true
 
   qs@6.13.0:
@@ -6394,6 +6446,10 @@ packages:
   restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -6621,6 +6677,14 @@ packages:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
 
+  slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -6659,6 +6723,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -6742,6 +6807,10 @@ packages:
   string-width@6.1.0:
     resolution: {integrity: sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==}
     engines: {node: '>=16'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -6865,6 +6934,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
@@ -7352,14 +7422,17 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -7666,6 +7739,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -7710,6 +7784,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -7759,6 +7837,11 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yaml@2.5.1:
+    resolution: {integrity: sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==}
+    engines: {node: '>= 14'}
+    hasBin: true
 
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
@@ -10428,6 +10511,10 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.0.1: {}
@@ -10481,7 +10568,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.7: {}
 
-  app-builder-lib@24.13.3(dmg-builder@25.0.5)(electron-builder-squirrel-windows@24.13.3):
+  app-builder-lib@24.13.3(dmg-builder@25.0.5(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@25.0.5)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.2.1
@@ -10515,7 +10602,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  app-builder-lib@25.0.5(dmg-builder@25.0.5)(electron-builder-squirrel-windows@24.13.3):
+  app-builder-lib@25.0.5(dmg-builder@25.0.5(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@25.0.5)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.3.2
@@ -11107,6 +11194,10 @@ snapshots:
     dependencies:
       restore-cursor: 4.0.0
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
   cli-highlight@2.1.11:
     dependencies:
       chalk: 4.1.2
@@ -11127,6 +11218,11 @@ snapshots:
       slice-ansi: 3.0.0
       string-width: 4.2.3
     optional: true
+
+  cli-truncate@4.0.0:
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
 
   cli-width@4.1.0: {}
 
@@ -11739,7 +11835,7 @@ snapshots:
 
   dmg-builder@25.0.5(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 25.0.5(dmg-builder@25.0.5)(electron-builder-squirrel-windows@24.13.3)
+      app-builder-lib: 25.0.5(dmg-builder@25.0.5(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@25.0.5))
       builder-util: 25.0.3
       builder-util-runtime: 9.2.5
       fs-extra: 10.1.0
@@ -11845,7 +11941,7 @@ snapshots:
 
   electron-builder-squirrel-windows@24.13.3(dmg-builder@25.0.5):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@25.0.5)(electron-builder-squirrel-windows@24.13.3)
+      app-builder-lib: 24.13.3(dmg-builder@25.0.5(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@25.0.5))
       archiver: 5.3.2
       builder-util: 24.13.1
       fs-extra: 10.1.0
@@ -11853,9 +11949,9 @@ snapshots:
       - dmg-builder
       - supports-color
 
-  electron-builder@25.0.5(electron-builder-squirrel-windows@24.13.3):
+  electron-builder@25.0.5(electron-builder-squirrel-windows@24.13.3(dmg-builder@25.0.5)):
     dependencies:
-      app-builder-lib: 25.0.5(dmg-builder@25.0.5)(electron-builder-squirrel-windows@24.13.3)
+      app-builder-lib: 25.0.5(dmg-builder@25.0.5(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@25.0.5))
       builder-util: 25.0.3
       builder-util-runtime: 9.2.5
       chalk: 4.1.2
@@ -11959,6 +12055,8 @@ snapshots:
   entities@4.5.0: {}
 
   env-paths@2.2.1: {}
+
+  environment@1.1.0: {}
 
   err-code@2.0.3: {}
 
@@ -12444,6 +12542,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-func-name@2.0.2: {}
 
   get-intrinsic@1.2.4:
@@ -12852,6 +12952,12 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@4.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-generator-function@1.0.10:
     dependencies:
       has-tostringtag: 1.0.2
@@ -13133,6 +13239,30 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lint-staged@15.2.10:
+    dependencies:
+      chalk: 5.3.0
+      commander: 12.1.0
+      debug: 4.3.7
+      execa: 8.0.1
+      lilconfig: 3.1.2
+      listr2: 8.2.5
+      micromatch: 4.0.8
+      pidtree: 0.6.0
+      string-argv: 0.3.2
+      yaml: 2.5.1
+    transitivePeerDependencies:
+      - supports-color
+
+  listr2@8.2.5:
+    dependencies:
+      cli-truncate: 4.0.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.1
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
   lit-element@4.1.1:
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.2.1
@@ -13209,6 +13339,14 @@ snapshots:
     dependencies:
       chalk: 5.3.0
       is-unicode-supported: 1.3.0
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.1.0
+      wrap-ansi: 9.0.2
 
   log4js@6.9.1:
     dependencies:
@@ -13625,6 +13763,8 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  mimic-function@5.0.1: {}
+
   mimic-response@1.0.1: {}
 
   mimic-response@3.1.0: {}
@@ -13959,6 +14099,10 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   oniguruma-to-js@0.4.3:
     dependencies:
       regex: 4.3.2
@@ -14219,13 +14363,14 @@ snapshots:
     dependencies:
       postcss: 8.4.47
 
-  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.1):
+  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.1)(yaml@2.5.1):
     dependencies:
       lilconfig: 3.1.2
     optionalDependencies:
       jiti: 1.21.6
       postcss: 8.4.47
       tsx: 4.19.1
+      yaml: 2.5.1
 
   postcss-merge-longhand@7.0.4(postcss@8.4.47):
     dependencies:
@@ -14634,6 +14779,11 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
   retry@0.12.0: {}
 
   reusify@1.0.4: {}
@@ -14881,6 +15031,16 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
     optional: true
 
+  slice-ansi@5.0.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 4.0.0
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 5.1.0
+
   smart-buffer@4.2.0: {}
 
   socks-proxy-agent@6.2.1:
@@ -15015,6 +15175,12 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 10.4.0
+      strip-ansi: 7.1.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.4.0
+      get-east-asian-width: 1.6.0
       strip-ansi: 7.1.0
 
   string_decoder@1.1.1:
@@ -15295,25 +15461,6 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.5.5)(typescript@5.8.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.5.5
-      acorn: 8.12.1
-      acorn-walk: 8.3.3
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.8.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
   tsconfck@3.1.3(typescript@5.8.2):
     optionalDependencies:
       typescript: 5.8.2
@@ -15330,7 +15477,7 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@8.3.0(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.1)(typescript@5.8.2):
+  tsup@8.3.0(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.1)(typescript@5.8.2)(yaml@2.5.1):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -15341,7 +15488,7 @@ snapshots:
       execa: 5.1.1
       joycon: 3.1.1
       picocolors: 1.1.0
-      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.1)
+      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.1)(yaml@2.5.1)
       resolve-from: 5.0.0
       rollup: 4.21.2
       source-map: 0.8.0-beta.0
@@ -15415,7 +15562,7 @@ snapshots:
 
   typed-query-selector@2.12.0: {}
 
-  typeorm@0.3.20(sql.js@1.11.0)(sqlite3@5.1.6(encoding@0.1.13))(ts-node@10.9.2(@types/node@22.5.5)(typescript@5.8.2)):
+  typeorm@0.3.20(sql.js@1.11.0)(sqlite3@5.1.6(encoding@0.1.13))(ts-node@10.9.2(@types/node@20.16.5)(typescript@5.8.2)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       app-root-path: 3.1.0
@@ -15435,7 +15582,7 @@ snapshots:
     optionalDependencies:
       sql.js: 1.11.0
       sqlite3: 5.1.6(encoding@0.1.13)
-      ts-node: 10.9.2(@types/node@22.5.5)(typescript@5.8.2)
+      ts-node: 10.9.2(@types/node@20.16.5)(typescript@5.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -16151,6 +16298,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.0
+
   wrappy@1.0.2: {}
 
   ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@6.0.4):
@@ -16178,6 +16331,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yaml@2.5.1: {}
 
   yargs-parser@20.2.9: {}
 


### PR DESCRIPTION
This pull request introduces a comprehensive annotation (批注) system for EPUB files, enabling users to create, update, and remove highlights and notes directly in VSCode. Annotations are stored in a sidecar JSON file alongside the EPUB, preserving the original file. The changes span the backend (shared package), documentation, and VSCode extension, and also introduce a more configurable logging system..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added EPUB annotation support: create highlights and optional text notes stored in sidecar JSON files alongside EPUBs
  * Annotation management features: list, edit, delete annotations with color options and chapter filtering
  * Enhanced logging system with configurable verbosity levels (Error, Warn, Info, Debug, Trace)

* **Documentation**
  * Added EPUB annotation guide explaining highlights, notes, and sidecar file storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->